### PR TITLE
Add publishing

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -1,0 +1,36 @@
+name: Publish to PyPi
+
+on:
+  push:
+    branches:
+      - main
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  publish:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    name: Publish
+    runs-on: ubuntu-latest
+    environment: pypi
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Hatch
+        uses: pypa/hatch@install
+
+      - name: Build package
+        run: hatch build
+
+      - name: Publish package
+        run: hatch publish -n
+        env:
+          HATCH_INDEX_USER: ${{ secrets.PYPI_USERNAME }}
+          HATCH_INDEX_AUTH: ${{ secrets.PYPI_AUTH }}

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -15,7 +15,12 @@ jobs:
 
     name: Publish
     runs-on: ubuntu-latest
-    environment: pypi
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pipelining-colemann
+
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
       - name: Clone repository
@@ -29,8 +34,5 @@ jobs:
       - name: Build package
         run: hatch build
 
-      - name: Publish package
-        run: hatch publish -n
-        env:
-          HATCH_INDEX_USER: ${{ secrets.PYPI_USERNAME }}
-          HATCH_INDEX_AUTH: ${{ secrets.PYPI_AUTH }}
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ example.py
 
 # dist
 dist/
+_version.py

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ htmlcov/
 
 # other
 example.py
+
+# dist
+dist/

--- a/pipelining/__about__.py
+++ b/pipelining/__about__.py
@@ -1,0 +1,6 @@
+__title__ = "pipelining-colemann"
+__version__ = "0.0.1"
+__author__ = "Noah Coleman"
+__license__ = "MIT"
+__email__ = "colemanmnoah@gmail.com"
+__description__ = "A lightweight, object-orientated pipeline framework in Python"

--- a/pipelining/__about__.py
+++ b/pipelining/__about__.py
@@ -1,6 +1,0 @@
-__title__ = "pipelining-colemann"
-__version__ = "0.0.1"
-__author__ = "Noah Coleman"
-__license__ = "MIT"
-__email__ = "colemanmnoah@gmail.com"
-__description__ = "A lightweight, object-orientated pipeline framework in Python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pipelining-colemann"
 dynamic = ["version"]
 description = 'A lightweight, object-orientated pipeline framework in Python'
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.13.3"
 license = "MIT"
 keywords = []
 authors = [
@@ -16,11 +16,7 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -21,13 +21,8 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "ruff>=0.11.8,<0.12",
-  "mypy>=1.15.0,<2",
-  "python>=3.13.3,<3.14",
-  "pytest>=8.3.5,<9",
-  "rich>=14.0.0,<15",
-  "pytest-cov>=6.1.1,<7",
-  "tqdm>=4.67.1,<5",
+  "rich",
+  "tqdm",
 ]
 
 [project.urls]
@@ -36,7 +31,7 @@ Issues = "https://github.com/colemannoah/pipelining/issues"
 Source = "https://github.com/colemannoah/pipelining"
 
 [tool.hatch.version]
-path = "pipelining/__about__.py"
+source = "vcs"
 
 [tool.hatch.build.targets.sdist]
 exclude = [
@@ -55,6 +50,12 @@ exclude = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["pipelining"]
+
+[tool.hatch.build.hooks.vcs]
+version-file = "_version.py"
+
+[tool.hatch.version.raw-options]
+version_scheme = "no-guess-dev"
 
 [tool.hatch.envs.types]
 extra-dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,88 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pipelining-colemann"
+dynamic = ["version"]
+description = 'A lightweight, object-orientated pipeline framework in Python'
+readme = "README.md"
+requires-python = ">=3.8"
+license = "MIT"
+keywords = []
+authors = [
+  { name = "colemannoah", email = "colemanmnoah@gmail.com" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = [
+  "ruff>=0.11.8,<0.12",
+  "mypy>=1.15.0,<2",
+  "python>=3.13.3,<3.14",
+  "pytest>=8.3.5,<9",
+  "rich>=14.0.0,<15",
+  "pytest-cov>=6.1.1,<7",
+  "tqdm>=4.67.1,<5",
+]
+
+[project.urls]
+Documentation = "https://github.com/colemannoah/pipelining#readme"
+Issues = "https://github.com/colemannoah/pipelining/issues"
+Source = "https://github.com/colemannoah/pipelining"
+
+[tool.hatch.version]
+path = "pipelining/__about__.py"
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/.github",
+  "/.mypy_cache",
+  "/.pixi",
+  "/.pytest_cache",
+  "/.ruff_cache",
+  "/.vscode",
+  "/htmlcov",
+  "/**/__pycache__/*",
+  "/.coverage",
+  "/.coverage.*",
+  "/example.py",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["pipelining"]
+
+[tool.hatch.envs.types]
+extra-dependencies = [
+  "mypy>=1.0.0",
+]
+
+[tool.hatch.envs.types.scripts]
+check = "mypy --install-types --non-interactive {args:pipelining tests}"
+
+[tool.coverage.run]
+source_pkgs = ["pipelining", "tests"]
+branch = true
+parallel = true
+omit = [
+  "pipelining/__about__.py",
+]
+
+[tool.coverage.paths]
+pipelining = ["pipelining", "*/pipelining"]
+tests = ["tests", "*/tests"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]


### PR DESCRIPTION
# Summary
- Add `pyproject` TOML file for package definition.
  - Making use of `hatch` and `hatch-vcs`.
- Add a new publishing workflow, waiting for an active publisher to be approved.
